### PR TITLE
fix numbering of paragraphs starting with ifeval/ifdef

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,11 @@ function preprocessTemplate(tmp) {
       continue
     }
 
+    if (line.match(/^ifeval::/) || line.match(/^ifdef::/)) {
+      emptyLine = true
+      continue
+    }
+
     const parRgx = /^(\.+)(\s*\[\[([^\s]+)\]\])?/
     const numberedP = line.match(parRgx)
 


### PR DESCRIPTION
issue:
When a numbered paragraph would be wrapped like
```
ifeval::[{signing-bonus} != 0]
.. paragraph
endif::[]
```
The dots would not be replaced with a paragraph number, because it wasn't the first line of a block.

Solution:
When a block starts with `ifeval::` or `ifdef::`, set `emptyLine` flag to mark next line as a new block.