### PR TITLE
Add option for people outside EMS

### DIFF
--- a/assets/contract.css
+++ b/assets/contract.css
@@ -522,17 +522,6 @@ td>div.verse{
 @page { margin: 1.75cm }
 }
 
-#header::before {
-  content: " ";
-  display: block;
-  background-image: url('logo.png');
-  background-repeat: no-repeat;
-  background-size: cover;
-  width: 273px;
-  height: 40px;
-  margin: 0 auto 40px;
-}
-
 #header>h1:only-child {
   border-bottom: 0;
 }

--- a/assets/logo.css
+++ b/assets/logo.css
@@ -1,0 +1,10 @@
+#header::before {
+    content: " ";
+    display: block;
+    background-image: url('logo.png');
+    background-repeat: no-repeat;
+    background-size: cover;
+    width: 273px;
+    height: 40px;
+    margin: 0 auto 40px;
+  }

--- a/now.json
+++ b/now.json
@@ -19,6 +19,7 @@
   ],
   "routes": [
     {"src": "/assets/contract.css", "dest": "/assets/contract.css"},
+    {"src": "/assets/logo.css", "dest": "/assets/logo.css"},
     {"src": "/assets/app.css", "dest": "/assets/app.css"},
     {"src": "/favicon.ico", "dest": "/assets/favicon.ico"},
     {"src": "/assets/logo.png", "dest": "/assets/logo.png"},

--- a/src/contract.js
+++ b/src/contract.js
@@ -11,11 +11,13 @@ const contract = async (req, res) => {
   
   const emsData = useEms ? await loadEMS(date) : undefined
   const people = getPeople(req, emsData)
+  const withLogo = useEms
 
   const contracts = await createPdfContracts(
     req,
     people,
     contractName,
+    withLogo
   )
   return sendContracts(res, people, contracts)
 }

--- a/src/contract.js
+++ b/src/contract.js
@@ -7,8 +7,9 @@ import {createPdfContracts} from './utils/createPdfContracts'
 const contract = async (req, res) => {
   if (!(await authorize(req, res))) return
 
-  const {contractName, date} = getParams(req)
-  const emsData = await loadEMS(date)
+  const {contractName, date, useEms} = getParams(req)
+  
+  const emsData = useEms ? await loadEMS(date) : undefined
   const people = getPeople(req, emsData)
 
   const contracts = await createPdfContracts(

--- a/src/utils/createHtmlContracts.js
+++ b/src/utils/createHtmlContracts.js
@@ -2,7 +2,7 @@ import _asciidoctor from 'asciidoctor.js'
 import {file} from '../api'
 import evalFunction from '../evalFunction'
 import {preprocessTemplate} from './preprocessTemplate'
-import {getSigningDates, shouldRemovePandadocTags} from './parsing'
+import {getEmployers, getSigningDates, shouldRemovePandadocTags} from './parsing'
 import {objToAdocVars} from './objToAdocVars'
 import {loadSheetData} from './sheets'
 
@@ -20,6 +20,7 @@ export const createHtmlContracts = async (
   const templateFunction = await file(req, `${contractName}.js`)
 
   const signingDates = getSigningDates(req)
+  const employers = getEmployers(req)
 
   const htmlContracts = await Promise.all(
     people.map(async (person, i) => {
@@ -27,6 +28,7 @@ export const createHtmlContracts = async (
         ...req.query,
         id: person.jiraId,
         signing_date: signingDates[i],
+        employer_id: employers[i],
         loadSheetData,
       }
 

--- a/src/utils/createHtmlContracts.js
+++ b/src/utils/createHtmlContracts.js
@@ -2,7 +2,7 @@ import _asciidoctor from 'asciidoctor.js'
 import {file} from '../api'
 import evalFunction from '../evalFunction'
 import {preprocessTemplate} from './preprocessTemplate'
-import {getEmployers, getSigningDates, shouldRemovePandadocTags} from './parsing'
+import {paramNames, getFilledParamValues, shouldRemovePandadocTags} from './parsing'
 import {objToAdocVars} from './objToAdocVars'
 import {loadSheetData} from './sheets'
 
@@ -19,8 +19,9 @@ export const createHtmlContracts = async (
   )
   const templateFunction = await file(req, `${contractName}.js`)
 
-  const signingDates = getSigningDates(req)
-  const employers = getEmployers(req)
+  const signingDates = getFilledParamValues(req, paramNames.signingDate)
+  const startDates = getFilledParamValues(req, paramNames.startDate, true)
+  const employers = getFilledParamValues(req, paramNames.employer, true)
 
   const htmlContracts = await Promise.all(
     people.map(async (person, i) => {
@@ -28,6 +29,7 @@ export const createHtmlContracts = async (
         ...req.query,
         id: person.jiraId,
         signing_date: signingDates[i],
+        start_date: startDates[i],
         employer_id: employers[i],
         loadSheetData,
       }

--- a/src/utils/parsing.js
+++ b/src/utils/parsing.js
@@ -52,6 +52,16 @@ export const getSigningDates = (req) => {
   return filledDates
 }
 
+export const getEmployers = (req) => {
+  const employerParam = req.query.employer
+  if (!employerParam) return []
+  
+  const employers = employerParam.split(',')
+  const filledEmployers = employers.map((employer) => employer || employers[0])
+
+  return filledEmployers
+}
+
 export const shouldRemovePandadocTags = (req) => {
   const endpoint = req.url.split('/')[1]
   return endpoint.match(/pandadoc/gi) ? false : true

--- a/src/utils/parsing.js
+++ b/src/utils/parsing.js
@@ -13,7 +13,8 @@ export const getParams = (req) => {
   const params = req.url.split('/').slice(2)
   const contractName = params[0]
   const date = params[1].split('?')[0]
-  return {contractName, date}
+  const useEms = req.query.ems !== 'false'
+  return {contractName, date, useEms}
 }
 
 const validatePeople = (people, ids) => {
@@ -30,8 +31,13 @@ const validatePeople = (people, ids) => {
 export const getPeople = (req, emsData) => {
   const ids = req.query.id.split(',')
 
-  const people = ids.map((id) => emsData.find((e) => e.jiraId === id))
-  validatePeople(people, ids)
+  let people
+  if (emsData) {
+    people = ids.map((id) => emsData.find((e) => e.jiraId === id))
+    validatePeople(people, ids)
+  } else {
+    people = ids.map((id) => {return {jiraId: id}})
+  }
 
   return people
 }

--- a/src/utils/parsing.js
+++ b/src/utils/parsing.js
@@ -2,12 +2,19 @@ import _ from 'lodash'
 import url from 'url'
 import c from '../config'
 
-export const getCssUrl = (req) =>
-  url.format({
+export const getCssUrls = (req, withLogo) => { 
+  const getCssUrl = (cssPath) => url.format({
     protocol: req.headers['x-forwarded-proto'] || c.isHttps ? 'https' : 'https',
     host: req.headers.host,
-    pathname: '/assets/contract.css',
+    pathname: cssPath,
   })
+
+  const contractCssUrl = getCssUrl('/assets/contract.css')
+  if (!withLogo) return [contractCssUrl]
+  
+  const logoCssUrl = getCssUrl('/assets/logo.css')
+  return [contractCssUrl, logoCssUrl]
+}
 
 export const getParams = (req) => {
   const params = req.url.split('/').slice(2)

--- a/src/utils/parsing.js
+++ b/src/utils/parsing.js
@@ -2,6 +2,12 @@ import _ from 'lodash'
 import url from 'url'
 import c from '../config'
 
+export const paramNames = {
+  signingDate: 'signing_date',
+  startDate: 'start_date',
+  employer: 'employer',
+}
+
 export const getCssUrls = (req, withLogo) => { 
   const getCssUrl = (cssPath) => url.format({
     protocol: req.headers['x-forwarded-proto'] || c.isHttps ? 'https' : 'https',
@@ -49,24 +55,19 @@ export const getPeople = (req, emsData) => {
   return people
 }
 
-export const getSigningDates = (req) => {
-  const dates = req.query.signing_date.split(',')
-
-  if (dates[0] === '') throw 'signing_date not specified.'
-
-  const filledDates = dates.map((date) => date || dates[0])
-
-  return filledDates
-}
-
-export const getEmployers = (req) => {
-  const employerParam = req.query.employer
-  if (!employerParam) return []
+export const getFilledParamValues = (req, paramName, isOptional) => {
+  const param = req.query[paramName]
+  if (!param) {
+    if (isOptional) return []
+    throw `${param} not specified.`
+  }
   
-  const employers = employerParam.split(',')
-  const filledEmployers = employers.map((employer) => employer || employers[0])
+  const values = param.split(',')
+  if (!isOptional && values[0] === '') throw `${param} not specified.`
 
-  return filledEmployers
+  const filledValues = values.map((value) => value || values[0])
+
+  return filledValues
 }
 
 export const shouldRemovePandadocTags = (req) => {

--- a/src/utils/sheets.js
+++ b/src/utils/sheets.js
@@ -30,7 +30,7 @@ export const loadSheetData = async (person, sheet) => {
     return obj
   }, {}),
   )
-  .find((row) => row[sheet.idSheetsColumn] === person[sheet.idEMSField])
+  .find((row) => row[sheet.idSheetsColumn] == person[sheet.idEMSField])
 
   if (!indexedRow) throw new Error(`Error joining column ${sheet.idSheetsColumn} of spreadsheet https://docs.google.com/spreadsheets/d/${sheet.spreadsheetId} with column ${sheet.idEMSField} of EMS. Check if ${sheet.idEMSField} of user ID ${person.jiraId} exists in column ${sheet.idSheetsColumn}.`)
   


### PR DESCRIPTION
So far, the contract generator expected all ids in the URL to be jiraIds from EMS. We want to change this to allow creating contracts for covid testing project.

With an optional parameter `?ems=0`, ids are not taken from EMS. This will allow creating contracts using only data from Google Sheets, for people not in EMS. These contracts should be without VL logo on top.

We also add an optional `employers` parameter to be able to use one contract template with multiple employers.

The original contract generator was built pretty much around EMS, so this is a little hacky solution (we have to mock EMS data). In future refactor, I'd suggest we allow extracting data from multiple sources (now EMS, Google sheets, and query params) with equal weights/importance. For each contract, its data sources (together with information about optional/required) would be defined in the JS contract template.