### PR TITLE
Allow page breaks inside tables

### DIFF
--- a/assets/contract.css
+++ b/assets/contract.css
@@ -390,7 +390,7 @@ a{color:inherit!important;text-decoration:underline!important}
 a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
 a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
 abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+pre,blockquote,img,object,svg{page-break-inside:avoid}
 thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
@@ -437,9 +437,6 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 @media print {
   #footer {
     display: none;
-  }
-  table {
-    break-inside: avoid;
   }
 }
 


### PR DESCRIPTION
This is needed to support two-column templates because these are structured as a two-column table (see https://github.com/vacuumlabs/contracts/blob/master/archived/IT_SZCO_Combi_Bilingual.adoc). 

This also allows breaking inside tables where we don't want it, so if there's a way to disable breaking for specific tables within adoc template, that would be preferable - I just didn't find any simple solution.