### PR TITLE
[IIT-549] Move EMS API key into headers

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -30,7 +30,10 @@ export const file = async (req, filename) => {
 export const loadEMS = async (date) => {
   const emsData = (
     await axios.get(
-      `https://ems.vacuumlabs.com/api/monthlyExport?apiKey=${c.emsKey}&date=${date}`,
+      `https://ems.vacuumlabs.com/api/monthlyExport?date=${date}`,
+      {
+        headers: { 'api-key': c.emsKey },
+      }
     )
   ).data
 


### PR DESCRIPTION
EMS API key used to be in query - security issue.
The usual approach is to pass the key in headers - won't be visible in logs.