### PR TITLE
Fix email sending

### DIFF
--- a/src/utils/parsing.js
+++ b/src/utils/parsing.js
@@ -92,9 +92,9 @@ export const shouldRemovePandadocTags = (req) => {
 }
 
 export const shouldEmailCompany = (req) => {
-  return !!req.query.sendEmailToCompany
+  return req.query.sendEmailToCompany === 'true'
 }
 
 export const shouldEmailSpot = (req) => {
-  return !!req.query.sendEmailToSpot
+  return req.query.sendEmailToSpot === 'true'
 }


### PR DESCRIPTION
The value of the query is string. Double negation would result in true even though it was 'false'.